### PR TITLE
Add option to disable the IRC nick prefix in Telegram messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ You must disable the privacy mode for your bot.
 * __ircnick__: The bot's nickname in IRC
 * __ircport__, __ircserver__, __ircssl__, __ircpass__: How to connect to the IRC server. `ircpass` is optional, can be blank.
 * __offset__: Use 0 for the first time, don't manually change it after
+* __shownick__: true/false, Enable/disable prefixing of messages sent to Telegram with the IRC nick of the sender (enabled by default)
 * __t2i__: true/false, Enable/disable Telegram to IRC forwarding
 * __token__: Your bot's token
 * __servemedia__ (_Optional_): Can be "" or "self" or "vim-cn".

--- a/relay.py
+++ b/relay.py
@@ -383,15 +383,20 @@ def processmsg():
         if cls == 0:
             rid = msg['message_id']
             if CFG.get('i2t') and '_ircuser' in msg:
-                rid = sync_sendmsg('[%s] %s' % (msg['_ircuser'], msg['text']), msg['chat']['id'])['message_id']
+                if CFG.get('shownick'):
+                    rid = sync_sendmsg('[%s] %s' % (msg['_ircuser'], msg['text']), msg['chat']['id'])['message_id']
+                else:
+                    rid = sync_sendmsg('%s' % msg['text'], msg['chat']['id'])['message_id']
             command(msg['text'], msg['chat']['id'], rid, msg)
         elif cls == 2:
             if CFG.get('i2t'):
                 act = re_ircaction.match(msg['text'])
                 if act:
                     sendmsg('** %s %s **' % (msg['_ircuser'], act.group(1)), msg['chat']['id'])
-                else:
+                elif CFG.get('shownick'):
                     sendmsg('[%s] %s' % (msg['_ircuser'], msg['text']), msg['chat']['id'])
+                else:
+                    sendmsg('%s' % msg['text'], msg['chat']['id'])
         elif cls == -1:
             sendmsg('Wrong usage', msg['chat']['id'], msg['message_id'])
 
@@ -537,6 +542,8 @@ CFG = json.load(open('config.json', 'r', encoding='utf-8'))
 CFG['offset'] = CFG.get('offset', 0)
 URL = 'https://api.telegram.org/bot%s/' % CFG['token']
 URL_FILE = 'https://api.telegram.org/file/bot%s/' % CFG['token']
+
+CFG.setdefault('shownick', True)
 
 MSG_Q = queue.Queue()
 executor = concurrent.futures.ThreadPoolExecutor(3)


### PR DESCRIPTION
Hey, this is my first time creating a pull request, how exciting :-)

I don't know much about Python, so this may not be implemented in the most elegant way possible :grin: 
